### PR TITLE
ESP32C5 hotfix

### DIFF
--- a/src/pn532_ble.cpp
+++ b/src/pn532_ble.cpp
@@ -16,7 +16,11 @@ PN532_BLE::~PN532_BLE()
     if (NimBLEDevice::isInitialized())
     {
         pn532bleBuffer.clear();
-        NimBLEDevice::deinit(true);
+    #if defined(CONFIG_IDF_TARGET_ESP32C5)
+        esp_bt_controller_deinit();
+    #else
+        BLEDevice::deinit();
+    #endif
     }
 }
 


### PR DESCRIPTION
BLEDevice::deinit() makes ESP32C5 crash for some odd reason.

turning off the driver directly fixes it for now.